### PR TITLE
updated docker-compose for traefik 2.1

### DIFF
--- a/demo-setup/Readme.md
+++ b/demo-setup/Readme.md
@@ -1,0 +1,21 @@
+# Updated files for demo
+Video of the demo is described in [this video](https://www.youtube.com/watch?v=4jI5GM_AOFs)
+
+contains:
+
+* docker-compose file
+* traefik.toml for traefik 2.1
+
+You need to:
+
+* have control over four subdomains:
+ * auth.my-domain.org  (keycloak will be launched here)
+ * triplestore.my-domain.org  (the jena-fuseki)
+ * app1.my-domain.org  (the test application)
+ * www.my-domain.org   (a small hello-world to test certificates)
+* These domains should all point to the same IP-address, which is the external IP of the machine you will be cloning this repo into
+
+Afterwards:
+1. replace in the docker-compose my-domain.org for your actual domain
+2. change the admin password for keycloak  (line 79)
+3. ```docker-compose up```

--- a/demo-setup/docker-compose.yml
+++ b/demo-setup/docker-compose.yml
@@ -1,0 +1,105 @@
+version: '3'
+
+networks:
+  default:
+    driver: bridge
+  traefik:
+    internal: true
+
+services:
+  reverse-proxy:
+    # The official v2 Traefik docker image
+    image: traefik:v2.1
+    # Enables the web UI and tells Traefik to listen to docker
+    command: --providers.docker
+    networks:
+      - default
+      - traefik
+    restart: always
+    ports:
+      # The HTTP port
+      - "80:80"
+      # The Web UI (enabled by --api.insecure=true)
+      # - "8080:8080"
+      - "443:443"
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik.toml:/traefik.toml
+      - ./data/:/tmp
+
+  whoami:
+    # A container that exposes an API to show its IP address
+    image: containous/whoami
+    container_name: whoami
+    restart: always
+    networks:
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.whoami-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.whoami-http.entrypoints=web"
+      - "traefik.http.routers.whoami-http.rule=Host(`www.my-domain.org`)"
+      - "traefik.http.routers.whoami-http.middlewares=whoami-https@docker"
+      - "traefik.http.routers.whoami.entrypoints=web-secure"
+      - "traefik.http.routers.whoami.rule=Host(`www.my-domain.org`)"
+      - "traefik.http.routers.whoami.tls=true"
+      - "traefik.http.routers.whoami.tls.certresolver=default"
+    depends_on:
+      - reverse-proxy
+
+
+  fuseki:
+    image: "linkedsolutions/fuseki-oidc"
+    networks:
+      - default
+    depends_on:
+      - "keycloak"
+    volumes:
+      - ./db:/db
+    environment:
+      AUTH_SERVER_URL: "https://auth.my-domain.org/auth"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.triplestore-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.triplestore-http.entrypoints=web"
+      - "traefik.http.routers.triplestore-http.rule=Host(`triplestore.my-domain.org`)"
+      - "traefik.http.routers.triplestore-http.middlewares=triplestore-https@docker"
+      - "traefik.http.routers.triplestore.entrypoints=web-secure"
+      - "traefik.http.routers.triplestore.rule=Host(`triplestore.my-domain.org`)"
+      - "traefik.http.routers.triplestore.tls=true"
+      - "traefik.http.routers.triplestore.tls.certresolver=default"
+
+  keycloak:
+    image: "jboss/keycloak"
+    networks:
+      - default
+    environment:
+      KEYCLOAK_USER: "admin"
+      KEYCLOAK_PASSWORD: "CHANGE!!:keycloak_admin_password_in_quotes"
+      PROXY_ADDRESS_FORWARDING: "true" # needed when run behind a reverse proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.auth-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.auth-http.entrypoints=web"
+      - "traefik.http.routers.auth-http.rule=Host(`auth.my-domain.org`)"
+      - "traefik.http.routers.auth-http.middlewares=auth-https@docker"
+      - "traefik.http.routers.auth.entrypoints=web-secure"
+      - "traefik.http.routers.auth.rule=Host(`auth.my-domain.org`)"
+      - "traefik.http.routers.auth.tls=true"
+      - "traefik.http.routers.auth.tls.certresolver=default"
+
+  sample:
+    image: "linkedsolutions/fuseki-oidc-sample-client"
+    networks:
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.app1-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.app1-http.entrypoints=web"
+      - "traefik.http.routers.app1-http.rule=Host(`app1.my-domain.org`)"
+      - "traefik.http.routers.app1-http.middlewares=app1-https@docker"
+      - "traefik.http.routers.app1.entrypoints=web-secure"
+      - "traefik.http.routers.app1.rule=Host(`app1.my-domain.org`)"
+      - "traefik.http.routers.app1.tls=true"
+      - "traefik.http.routers.app1.tls.certresolver=default"

--- a/demo-setup/traefik.toml
+++ b/demo-setup/traefik.toml
@@ -1,0 +1,24 @@
+[api]
+  dashboard = true
+  debug = true
+
+[log]
+  level = "ERROR"
+
+[providers.docker]
+  exposedByDefault = false
+  network = "traefik"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":80"
+  [entryPoints.web-secure]
+    address = ":443"
+  [entryPoints.dashboard]
+    address = ":8080"
+
+[certificatesResolvers]
+  [certificatesResolvers.default.acme]
+    email = "contact@myemail.com"
+    storage = "acme.json"
+    [certificatesResolvers.default.acme.tlsChallenge]


### PR DESCRIPTION
Updated the docker-compose and toml file for version 2.1 of traefik, which is now the standard one. These files should be able to re-create the demo in the video. https://www.youtube.com/watch?v=4jI5GM_AOFs